### PR TITLE
Correct the order of Flags for Exp.Share Setup

### DIFF
--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -977,6 +977,14 @@ FaintEnemyPokemon:
 
 ;joedebug - EXP ALL is handled here
 
+; wispnote - If all participated PKMN fainted, only apply Exp.All
+ld a, [wPartyGainExpFlags]
+or a
+jr nz, .noZeroParticipants
+pop af
+jp .expallfix_end
+.noZeroParticipants
+
 ; the player has exp all
 ; first, we halve the values that determine exp gain
 ; the enemy mon base stats are added to stat exp, so they are halved

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -3389,12 +3389,17 @@ PlayerCalcMoveDamage:
 	call IsInArray
 ;;;;;;;;;;;;;;;;;;;;
 ;joenote - if there is a static damage effect like superfang or seismic toss, make it obey type immunities
+	ld a, [wUnusedC000] ; get ready to set or clear static damage flag
 	;jp c, .moveHitTest ; SetDamageEffects moves (e.g. Seismic Toss and Super Fang) skip damage calculation	;joenote - not needed anymore
 	jp nc, .not_static	;skip all this if not a static damage move
+	set 4, a
+	ld [wUnusedC000], a	;a static move, so set the flag
 	ld a, $1	;set wDamage to 1 point. just need a non-zero value otherwise it counts as a miss later on.
 	ld [wDamage], a
 	jr .static_skiphere		;skip the normal calculations for static damage moves
 .not_static
+	res 4, a
+	ld [wUnusedC000], a	;not a static move, so clear the flag
 ;;;;;;;;;;;;;;;;;;;;
 	call CriticalHitTest
 	call HandleCounterMove
@@ -5720,11 +5725,24 @@ AdjustDamageForMoveType:
 	push hl
 	push bc
 	inc hl
-	ld a, [wDamageMultipliers]
+	ld a, [wDamageMultipliers]	;this will be $0A or 8A on the first go around
 	and $80	;bug - this erases the first defensive type found, so the wrong message is displayed
 	ld b, a
-	ld a, [hl] ; a = damage multiplier
+	ld a, [hl] ; a = damage multiplier from type chart table (can be $00, $05, or $14)
 	ld [H_MULTIPLIER], a
+;;;;;;;;joenote - fixing the wrong effectiveness message for static damage moves
+	and a
+	jr z, .endmulti	;skip to end if the multiplier is zero
+	ld c, a
+	ld a, [wUnusedC000]
+	bit 4, a
+	ld a, c
+	jr z, .skip_static	;don't do anything if not a static move
+	ld a, [wDamageMultipliers]
+	and $7f	;keep the current multiplier if static move (will be either 00 or 0A)
+	jr .endmulti
+.skip_static
+;;;;;;;;
 ;;;;;;;;joenote - fixing the wrong effectiveness message 
 	cp $05	;multiplier is still in a, so see if it's half damage
 	jr nz, .nothalf	;skip ahead if not half
@@ -6185,12 +6203,17 @@ EnemyCalcMoveDamage:
 	call IsInArray	;set carry if a is found in array hl
 ;;;;;;;;;;;;;;;;;;;;
 ;joenote - if there is a static damage effect like superfang or seismic toss, make it obey type immunities
+	ld a, [wUnusedC000]	;get ready to set or reset static move flag
 ;	jp c, EnemyMoveHitTest	;joenote - don't need this anymore
 	jp nc, .not_static	;skip all this if not a static damage move
+	set 4, a
+	ld [wUnusedC000], a	;static move so set the flag
 	ld a, $1	;set wDamage to 1 point. just need a non-zero value otherwise it counts as a miss later on.
 	ld [wDamage], a
 	jr .static_skiphere		;skip the normal calculations for static damage moves
 .not_static
+	set 4, a
+	ld [wUnusedC000], a	;static move so set the flag
 ;;;;;;;;;;;;;;;;;;;;
 	call CriticalHitTest
 	call HandleCounterMove
@@ -7487,7 +7510,7 @@ PlayMoveAnimation:
 InitBattle:
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 	xor a
-	ld [wUnusedC000], a	;joenote - clear custom ai bits at battle start
+	ld [wUnusedC000], a	;joenote - clear custom ai bits and battle flags at battle start
 	ld [wUnusedD155], a	;joenote - clear backup location for how many pkmn recieve exp
 	ld [wUnusedD366], a ;joenote - clear ai switch tracker bits
 	;clear AI_Trainer switching bits

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -977,13 +977,14 @@ FaintEnemyPokemon:
 
 ;joedebug - EXP ALL is handled here
 
-; wispnote - If all participated PKMN fainted, only apply Exp.All
-ld a, [wPartyGainExpFlags]
-or a
-jr nz, .noZeroParticipants
-pop af
-jp .expallfix_end
-.noZeroParticipants
+;wispnote - If all participated PKMN fainted, only apply the Exp.All effect
+;			- Half the exp will be split among all non-fainted party mons
+	ld a, [wPartyGainExpFlags]
+	or a
+	jr nz, .noZeroParticipants
+	pop af
+	jp .expallfix_end	;all your battle participants are toast. don't even bother giving them exp
+	.noZeroParticipants
 
 ; the player has exp all
 ; first, we halve the values that determine exp gain

--- a/engine/battle/experience.asm
+++ b/engine/battle/experience.asm
@@ -19,8 +19,8 @@ GainExperience:
 .partyMonLoop ; loop over each mon and add gained exp
 	inc hl
 	ld a, [hli]
-	or [hl] ; is mon's HP 0?
-	jp z, .nextMon ; if so, go to next mon
+	; or [hl] ; is mon's HP 0? wispnote - We already handle this check separately, also makes debugging more difficult.
+	; jp z, .nextMon ; if so, go to next mon
 	push hl
 	ld hl, wPartyGainExpFlags
 	ld a, [wWhichPokemon]

--- a/engine/battle/experience.asm
+++ b/engine/battle/experience.asm
@@ -345,7 +345,7 @@ DivideExpDataByNumMonsGainingExp:
 	dec c
 	jr nz, .countSetBitsLoop
 	cp $2
-	ld[wUnusedD155], a	;joenote - make a backup of number of mons gaining exp
+	ld [wUnusedD155], a	;joenote - make a backup of number of mons gaining exp
 	ret c ; return if only one mon is gaining exp
 	ld [wd11e], a ; store number of mons gaining exp
 	ld hl, wEnemyMonBaseStats

--- a/engine/battle/experience.asm
+++ b/engine/battle/experience.asm
@@ -19,8 +19,10 @@ GainExperience:
 .partyMonLoop ; loop over each mon and add gained exp
 	inc hl
 	ld a, [hli]
-	; or [hl] ; is mon's HP 0? wispnote - We already handle this check separately, also makes debugging more difficult.
-	; jp z, .nextMon ; if so, go to next mon
+	; wispnote - We already handle this check separately, and also makes debugging more difficult.
+	; 	But it handles might handle unpredictabl on/off cases.
+	or [hl] ; is mon's HP 0? ; 
+	jp z, .nextMon ; if so, go to next mon
 	push hl
 	ld hl, wPartyGainExpFlags
 	ld a, [wWhichPokemon]

--- a/engine/battle/experience.asm
+++ b/engine/battle/experience.asm
@@ -20,7 +20,7 @@ GainExperience:
 	inc hl
 	ld a, [hli]
 	; wispnote - We already handle this check separately, and also makes debugging more difficult.
-	; 	But it handles might handle unpredictabl on/off cases.
+	; 	But it might handle unpredictable on/off cases.
 	or [hl] ; is mon's HP 0? ; 
 	jp z, .nextMon ; if so, go to next mon
 	push hl

--- a/engine/battle/stats_functions.asm
+++ b/engine/battle/stats_functions.asm
@@ -444,12 +444,10 @@ SetExpAllFlags:
 .gainExpFlagsLoop
 	ld a, [hli]
 	or [hl] ; is mon's HP 0?
-	jp z, .setzeroexpflag
+	jp z, .setnextexpflag
 	scf
-	rl b
-	jp .nextmonforexpall
-.setzeroexpflag
-	sla b
+.setnextexpflag
+	rr b
 .nextmonforexpall
 	dec c
 	jr z, .return
@@ -462,6 +460,8 @@ SetExpAllFlags:
 	pop bc
 	jr .gainExpFlagsLoop
 .return
+	rr b
+	rr b
 	ld a, b
 	ld [wPartyGainExpFlags], a
 	ret

--- a/engine/battle/stats_functions.asm
+++ b/engine/battle/stats_functions.asm
@@ -448,7 +448,6 @@ SetExpAllFlags:
 	scf
 .setnextexpflag
 	rr b
-.nextmonforexpall
 	dec c
 	jr z, .return
 	ld a, [wPartyCount]
@@ -460,6 +459,16 @@ SetExpAllFlags:
 	pop bc
 	jr .gainExpFlagsLoop
 .return
+	ld a, [wPartyCount]
+	ld c, a
+	ld a, 6
+	sub c
+.loopBitRotation
+	jp z, .finishVariableBitRotation
+	rr b
+	dec a
+	jr .loopBitRotation
+.finishVariableBitRotation
 	rr b
 	rr b
 	ld a, b

--- a/engine/battle/stats_functions.asm
+++ b/engine/battle/stats_functions.asm
@@ -441,13 +441,17 @@ SetExpAllFlags:
 	ld c, a
 	ld b, 0
 	ld hl, wPartyMon1HP
-.gainExpFlagsLoop
+.gainExpFlagsLoop	
+;wisp92 found that bits need to be rotated in from the left and shifted to the right. 
+;Bit 0 of the flags represents the first mon in the party
+;Bit 5 of the flags represents the sixth mon in the party
 	ld a, [hli]
 	or [hl] ; is mon's HP 0?
-	jp z, .setnextexpflag
-	scf
-.setnextexpflag
-	rr b
+	jp z, .setnextexpflag	;the carry bit is cleared from the last OR, so 0 will be rotated in next
+	scf	;the carry bit is is set, so 1 will be rotated in next
+.setnextexpflag 
+	jp .do_rotations	
+.nextmonforexpall
 	dec c
 	jr z, .return
 	ld a, [wPartyCount]
@@ -459,23 +463,36 @@ SetExpAllFlags:
 	pop bc
 	jr .gainExpFlagsLoop
 .return
-	ld a, [wPartyCount]
-	ld c, a
-	ld a, 6
-	sub c
-.loopBitRotation
-	jp z, .finishVariableBitRotation
-	rr b
-	dec a
-	jr .loopBitRotation
-.finishVariableBitRotation
-	rr b
-	rr b
 	ld a, b
 	ld [wPartyGainExpFlags], a
 	ret
-
-
+.do_rotations
+;need to rotate the carry value into the proper flag bit position
+;a and hl are free to use
+;c is the counter that tells the party position
+;b holds the current flag values
+	push af	;save carry value
+	;the number of rotations needed to move the carry value to the proper flag place is 8 - [wPartyCount] + c
+	ld a, $08
+	ld hl, wPartyCount 
+	sub [hl] ;subtract 1 to 6
+	add c	; add the current count
+	ld h, a
+	pop af	;get the carry value back
+	ld a, h
+	;a now has the rotation count (8 to 3)
+	push bc
+	ld c, a	;make c hold the rotation count
+	ld a, $00
+.loop
+	rr a	;rotate the carry value 1 bit to the right per loop
+	dec c
+	jr nz, .loop
+	pop bc
+	or b	;append current flag values to a
+	ld b, a	; and save them back to b
+	jp .nextmonforexpall
+	
 	
 ;This function is for teleporting you home from the start menu if you get stuck
 SoftlockTeleport:

--- a/wram.asm
+++ b/wram.asm
@@ -72,7 +72,7 @@ wUnusedC000:: ; c000
 ;bit 1 - if set, ai already acted by switching or using an item this turn
 ;bit 2 - if set, ai can swith or use item but not use a move (only run ai routine 4)
 ;bit 3 - used for AIGetTypeEffectiveness
-;bit 4 - unused 
+;bit 4 - if set, current move being handled is a static damaging move
 ;bit 5 - unused 
 ;bit 6 - if set, poison/burn damage algorithm is being called to handle leech seed
 ;bit 7 - if set, force Counter to miss (for an opponent hurting itself or its jump kick missing)


### PR DESCRIPTION
Corrected the SetExpAllFlags method in order to set the correct flags for Exp.Share (Reversed the direction of the rotation)

I also added an extra check to determine if any participants have not fainted. I decided to share all the XP in this case for two reasons. First, I don't see how some XP cannot be shared, and second, it was easier to implement.

Finally, I commented out one seemingly not necessary check in experience.asm. I tested it and seems OK, but maybe there are implications that I am not aware of.

EDIT: I merged the Text Fix for Fixed-Damage Moves to Lite.