### PR TITLE
Fix Incorrect Merging of Fixed-Damage Moves Text & SFX Patch

### DIFF
--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -6212,8 +6212,8 @@ EnemyCalcMoveDamage:
 	ld [wDamage], a
 	jr .static_skiphere		;skip the normal calculations for static damage moves
 .not_static
-	set 4, a
-	ld [wUnusedC000], a	;static move so set the flag
+	res 4, a
+	ld [wUnusedC000], a	;not a static move so reset the flag
 ;;;;;;;;;;;;;;;;;;;;
 	call CriticalHitTest
 	call HandleCounterMove


### PR DESCRIPTION
Correcting my incorrect merging. I accidentally set the Fixed-Damage Move Flag regardless of the opponent's move.

I tested it and it should be OK now.