### PR TITLE
Fix "Natural" Amazing Man Bug & Rival's Bubble Text

### DIFF
--- a/engine/overworld/movement.asm
+++ b/engine/overworld/movement.asm
@@ -127,7 +127,12 @@ UpdateNPCSprite:
 	and a
 	jp z, InitializeSpriteStatus
 	call CheckSpriteAvailability
-	ret c             ; if sprite is invisible, on tile >=$60, in grass or player is currently walking
+	; wispnote - Fixes the natural Amazing Man bugs (not the humanly provoked cases).
+	; Also, surprisingly, makes some previously invisble text appear, e.g., the rival's exclamation bubbles during the encounters in Route 22.
+	jp nc, .isAvailableSprite
+	call InitializeSpriteScreenPosition
+	ret; if sprite is invisible, on tile >=$60, in grass or player is currently walking
+.isAvailableSprite:
 	ld h, $c1
 	ld a, [H_CURRENTSPRITEOFFSET]
 	ld l, a


### PR DESCRIPTION
This is a partial fix to the Amazing Man Bug, since opening the menu while changing the map still reveals the bug.
However, it fixes, to the best of my knowledge, the natural cases in Cinnabar Island and the Bike Shop.
Also, it reveals some bubble text of the rival in Route 22 while he is still off-screen. It was not noticeable before but the behavior exists in the code.

EDIT: This is not as well tested as it should be. I need to make a new playthrough to see how it interacts with the rest of the scripting.