### PR TITLE
Victory Road: Tweak Variant for Lite Version

### DIFF
--- a/data/hide_show_data.asm
+++ b/data/hide_show_data.asm
@@ -401,7 +401,7 @@ MapHSC2:
 	db VICTORY_ROAD_2,$08,Show
 	db VICTORY_ROAD_2,$09,Show
 	db VICTORY_ROAD_2,$0A,Show
-	db VICTORY_ROAD_2,$0D,Show
+	db VICTORY_ROAD_2,$0D,Hide; wispnote - Set to Hide since the puzzle doesn't reset anymore.
 MapHS58:
 	db BILLS_HOUSE,$01,Show
 	db BILLS_HOUSE,$02,Hide

--- a/data/hide_show_data.asm
+++ b/data/hide_show_data.asm
@@ -401,7 +401,7 @@ MapHSC2:
 	db VICTORY_ROAD_2,$08,Show
 	db VICTORY_ROAD_2,$09,Show
 	db VICTORY_ROAD_2,$0A,Show
-	db VICTORY_ROAD_2,$0D,Hide; wispnote - Set to Hide since the puzzle doesn't reset anymore.
+	db VICTORY_ROAD_2,$0D,Show
 MapHS58:
 	db BILLS_HOUSE,$01,Show
 	db BILLS_HOUSE,$02,Hide

--- a/scripts/indigoplateaulobby.asm
+++ b/scripts/indigoplateaulobby.asm
@@ -5,7 +5,8 @@ IndigoPlateauLobbyScript:
 	bit 6, [hl]
 	res 6, [hl]
 	ret z
-	ResetEvent EVENT_VICTORY_ROAD_1_BOULDER_ON_SWITCH
+	; wispnote - This event was probably ment to be reset on Route 23.
+	; ResetEvent EVENT_VICTORY_ROAD_1_BOULDER_ON_SWITCH
 	ld hl, wBeatLorelei
 	bit 1, [hl]
 	res 1, [hl]

--- a/scripts/route23.asm
+++ b/scripts/route23.asm
@@ -10,6 +10,11 @@ Route23Script_511e9:
 	bit 6, [hl]
 	res 6, [hl]
 	ret z
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; wispnote - Resetting Victory Road Puzzle
+	; EVENT_VICTORY_ROAD_1_BOULDER_ON_SWITCH was probably mentto be reset here
+	; along with the rest of the puzzle instead on Indigo Plateau Loby.
+	ResetEvent EVENT_VICTORY_ROAD_1_BOULDER_ON_SWITCH
 	ResetEvents EVENT_VICTORY_ROAD_2_BOULDER_ON_SWITCH1, EVENT_VICTORY_ROAD_2_BOULDER_ON_SWITCH2
 	ResetEvents EVENT_VICTORY_ROAD_3_BOULDER_ON_SWITCH1, EVENT_VICTORY_ROAD_3_BOULDER_ON_SWITCH2
 	ld a, HS_VICTORY_ROAD_3_BOULDER
@@ -18,6 +23,7 @@ Route23Script_511e9:
 	ld a, HS_VICTORY_ROAD_2_BOULDER
 	ld [wMissableObjectIndex], a
 	predef_jump HideObject
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 Route23ScriptPointers:
 	dw Route23Script0

--- a/scripts/route23.asm
+++ b/scripts/route23.asm
@@ -1,7 +1,5 @@
 Route23Script:
-	; wispnote - Due to various evidence I suspect that the puzzle
-	; wasn't ment to be reset and this instruction was left for debugging purposes.
-	; call Route23Script_511e9
+	call Route23Script_511e9
 	call EnableAutoTextBoxDrawing
 	ld hl, Route23ScriptPointers
 	ld a, [wRoute23CurScript]

--- a/scripts/route23.asm
+++ b/scripts/route23.asm
@@ -1,19 +1,21 @@
 Route23Script:
-	call Route23Script_511e9
+	; wispnote - Due to various evidence I suspect that the puzzle
+	; wasn't ment to be reset and this instruction was left for debugging purposes.
+	; call Route23Script_511e9
 	call EnableAutoTextBoxDrawing
 	ld hl, Route23ScriptPointers
 	ld a, [wRoute23CurScript]
 	jp CallFunctionInTable
 
 Route23Script_511e9:
-	ld hl, wCurrentMapScriptFlags
-	bit 6, [hl]
-	res 6, [hl]
-	ret z
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; wispnote - Resetting Victory Road Puzzle
 	; EVENT_VICTORY_ROAD_1_BOULDER_ON_SWITCH was probably mentto be reset here
 	; along with the rest of the puzzle instead on Indigo Plateau Loby.
+	ld hl, wCurrentMapScriptFlags
+	bit 6, [hl]
+	res 6, [hl]
+	ret z
 	ResetEvent EVENT_VICTORY_ROAD_1_BOULDER_ON_SWITCH
 	ResetEvents EVENT_VICTORY_ROAD_2_BOULDER_ON_SWITCH1, EVENT_VICTORY_ROAD_2_BOULDER_ON_SWITCH2
 	ResetEvents EVENT_VICTORY_ROAD_3_BOULDER_ON_SWITCH1, EVENT_VICTORY_ROAD_3_BOULDER_ON_SWITCH2

--- a/scripts/victoryroad1.asm
+++ b/scripts/victoryroad1.asm
@@ -13,6 +13,18 @@ VictoryRoad1Script:
 .next
 	CheckEvent EVENT_VICTORY_ROAD_1_BOULDER_ON_SWITCH
 	ret z
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; wispnote - If the switch is activated place the boulder in switch's coordinates.
+; Sprite05 indexes the boulder, and ($11, $0D) are the swtich's coordinates.
+	ld hl, Sprite05MapY
+	ld a, $0D
+	add 4; wispnote - We need to offset coordinates by 4
+	ld [hl], a
+	ld hl, Sprite05MapX
+	ld a, $11
+	add 4; wispnote - We need to offset coordinates by 4
+	ld [hl], a
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 	ld a, $1d
 	ld [wNewTileBlockID], a
 	lb bc, 6, 4

--- a/scripts/victoryroad2.asm
+++ b/scripts/victoryroad2.asm
@@ -1,8 +1,12 @@
 VictoryRoad2Script:
-	ld hl, wCurrentMapScriptFlags
-	bit 6, [hl]
-	res 6, [hl]
-	call nz, VictoryRoad2Script_517c4
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; wispnote - Due to various evidence I suspect that the puzzle
+; wasn't ment to be reset and this instruction was left for debugging purposes.
+	; ld hl, wCurrentMapScriptFlags
+	; bit 6, [hl]
+	; res 6, [hl]
+	; call nz, VictoryRoad2Script_517c4
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 	ld hl, wCurrentMapScriptFlags
 	bit 5, [hl]
 	res 5, [hl]
@@ -22,6 +26,18 @@ VictoryRoad2Script_517c9:
 	CheckEvent EVENT_VICTORY_ROAD_2_BOULDER_ON_SWITCH1
 	jr z, .asm_517da
 	push af
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; wispnote - If the 1st switch is activated place the boulder in switch's coordinates.
+; Sprite11 indexes the 1st boulder, and ($01, $10) are the 1st swtich's coordinates.
+	ld hl, Sprite11MapY
+	ld a, $10
+	add 4; wispnote - We need to offset coordinates by 4
+	ld [hl], a
+	ld hl, Sprite11MapX
+	ld a, $01
+	add 4; wispnote - We need to offset coordinates by 4
+	ld [hl], a
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 	ld a, $15
 	lb bc, 4, 3
 	call VictoryRoad2Script_517e2
@@ -29,6 +45,20 @@ VictoryRoad2Script_517c9:
 .asm_517da
 	bit 7, a
 	ret z
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; wispnote - If the 2nd switch is activated place the boulder in switch's coordinates.
+; Sprite13 indexes the 2nd boulder, and ($09, $10) are the 2nd swtich's coordinates.
+; Not it should be impossible for a boulder to arrive there if Sprite13 is hidden;
+; therefore, there is no need to check.
+	ld hl, Sprite13MapY
+	ld a, $10
+	add 4; wispnote - We need to offset coordinates by 4
+	ld [hl], a
+	ld hl, Sprite13MapX
+	ld a, $09
+	add 4; wispnote - We need to offset coordinates by 4
+	ld [hl], a
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 	ld a, $1d
 	lb bc, 7, 11
 
@@ -49,7 +79,7 @@ VictoryRoad2Script0:
 	EventFlagAddress hl, EVENT_VICTORY_ROAD_2_BOULDER_ON_SWITCH1
 	ld a, [wCoordIndex]
 	cp $2
-	jr z, .asm_5180b
+	jr z, .asm_5180b; wispnote - Jump if the boulder is on the second coordinates.
 	CheckEventReuseHL EVENT_VICTORY_ROAD_2_BOULDER_ON_SWITCH1
 	SetEventReuseHL EVENT_VICTORY_ROAD_2_BOULDER_ON_SWITCH1
 	ret nz

--- a/scripts/victoryroad3.asm
+++ b/scripts/victoryroad3.asm
@@ -15,6 +15,18 @@ VictoryRoad3Script_44996:
 	ret z
 	CheckEventHL EVENT_VICTORY_ROAD_3_BOULDER_ON_SWITCH1
 	ret z
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; wispnote - If the switch is activated place the boulder in switch's coordinates.
+; Sprite07 indexes the first boulder, and ($03, $05) are the first swtich's coordinates.
+	ld hl, Sprite07MapY
+	ld a, $05
+	add 4; wispnote - We need to offset coordinates by 4
+	ld [hl], a
+	ld hl, Sprite07MapX
+	ld a, $03
+	add 4; wispnote - We need to offset coordinates by 4
+	ld [hl], a
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 	ld a, $1d
 	ld [wNewTileBlockID], a
 	lb bc, 5, 3
@@ -41,6 +53,8 @@ VictoryRoad3Script0:
 	SetEvent EVENT_VICTORY_ROAD_3_BOULDER_ON_SWITCH1
 	ret
 .asm_449dc
+	; wispnote - This event signifies that a boulder was thrown through a hole;
+	; it is not realted to any switch.
 	CheckAndSetEvent EVENT_VICTORY_ROAD_3_BOULDER_ON_SWITCH2
 	jr nz, .asm_449fe
 	ld a, HS_VICTORY_ROAD_3_BOULDER


### PR DESCRIPTION
With this tweak, the Victory Road Puzzle does not reset. Furthermore, the boulders corresponding to each switch are placed upon this switch after activation.

I believe this was the intended behavior. Resetting the puzzle only seems to hinder the path towards Indigo Plateau since the player can always move the boulders to make shortcuts on its way back. Furthermore, puzzles in RBY do not generally reset.

Known Issue: As is already the case for each tile that is replaced in run-time boulder sprite might be seen momentarily in their original places in cases the engine doesn't have enough time to process them. This happens usually when loading the whole map, e.g., after a battle or when falling through a hole. I think this is a different issue to be addressed separately.

EDIT: There is an alternative way to do this and get rid of the issue, but it requires the use of 3 to 6 new missable objects. Please tell me if you think it would be better.
