### PR TITLE
Victory Road: BugFix Variant for Lite Version

### DIFF
--- a/scripts/indigoplateaulobby.asm
+++ b/scripts/indigoplateaulobby.asm
@@ -5,7 +5,8 @@ IndigoPlateauLobbyScript:
 	bit 6, [hl]
 	res 6, [hl]
 	ret z
-	ResetEvent EVENT_VICTORY_ROAD_1_BOULDER_ON_SWITCH
+	; wispnote - This event was probably ment to be reset on Route 23.
+	; ResetEvent EVENT_VICTORY_ROAD_1_BOULDER_ON_SWITCH
 	ld hl, wBeatLorelei
 	bit 1, [hl]
 	res 1, [hl]

--- a/scripts/route23.asm
+++ b/scripts/route23.asm
@@ -6,10 +6,15 @@ Route23Script:
 	jp CallFunctionInTable
 
 Route23Script_511e9:
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; wispnote - Resetting Victory Road Puzzle
+	; EVENT_VICTORY_ROAD_1_BOULDER_ON_SWITCH was probably mentto be reset here
+	; along with the rest of the puzzle instead on Indigo Plateau Loby.
 	ld hl, wCurrentMapScriptFlags
 	bit 6, [hl]
 	res 6, [hl]
 	ret z
+	ResetEvent EVENT_VICTORY_ROAD_1_BOULDER_ON_SWITCH
 	ResetEvents EVENT_VICTORY_ROAD_2_BOULDER_ON_SWITCH1, EVENT_VICTORY_ROAD_2_BOULDER_ON_SWITCH2
 	ResetEvents EVENT_VICTORY_ROAD_3_BOULDER_ON_SWITCH1, EVENT_VICTORY_ROAD_3_BOULDER_ON_SWITCH2
 	ld a, HS_VICTORY_ROAD_3_BOULDER
@@ -18,6 +23,8 @@ Route23Script_511e9:
 	ld a, HS_VICTORY_ROAD_2_BOULDER
 	ld [wMissableObjectIndex], a
 	predef_jump HideObject
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 
 Route23ScriptPointers:
 	dw Route23Script0

--- a/scripts/victoryroad2.asm
+++ b/scripts/victoryroad2.asm
@@ -1,8 +1,12 @@
 VictoryRoad2Script:
-	ld hl, wCurrentMapScriptFlags
-	bit 6, [hl]
-	res 6, [hl]
-	call nz, VictoryRoad2Script_517c4
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; wispnote - Due to various evidence I suspect that the puzzle
+; wasn't ment to be reset and this instruction was left for debugging purposes.
+	; ld hl, wCurrentMapScriptFlags
+	; bit 6, [hl]
+	; res 6, [hl]
+	; call nz, VictoryRoad2Script_517c4
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 	ld hl, wCurrentMapScriptFlags
 	bit 5, [hl]
 	res 5, [hl]


### PR DESCRIPTION
This commit only fixes the reset conditions. The puzzle now only resets when the player enters Route 23.