### PR TITLE
Seafoam Islands : BugFix Variant for Lite Version

### DIFF
--- a/scripts/route20.asm
+++ b/scripts/route20.asm
@@ -1,7 +1,11 @@
 
 Route20Script:
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; wispnote - These routines reset the boulders' positions if the a floor's puzzle
+; is not completely solved but were neglecting to reset the individual events; an oversight.
 	CheckAndResetEvent EVENT_IN_SEAFOAM_ISLANDS
 	call nz, Route20Script_50cc6
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 	call EnableAutoTextBoxDrawing
 	ld hl, Route20TrainerHeader0
 	ld de, Route20ScriptPointers
@@ -18,6 +22,8 @@ Route20Script_50cc6:
 	call Route20Script_50d0c
 	ld a, HS_SEAFOAM_ISLANDS_1_BOULDER_2
 	call Route20Script_50d0c
+	; wispnote - Also reset the individual events.
+	ResetEvents EVENT_SEAFOAM3_BOULDER1_DOWN_HOLE, EVENT_SEAFOAM3_BOULDER2_DOWN_HOLE
 	ld hl, .MissableObjectIDs
 .asm_50cdc
 	ld a, [hli]
@@ -48,6 +54,8 @@ Route20Script_50cc6:
 	call Route20Script_50d14
 	ld a, HS_SEAFOAM_ISLANDS_5_BOULDER_2
 	call Route20Script_50d14
+	; wispnote - Also reset the individual events.
+	ResetEvents EVENT_SEAFOAM4_BOULDER1_DOWN_HOLE, EVENT_SEAFOAM4_BOULDER2_DOWN_HOLE
 	ret
 
 Route20Script_50d0c:


### PR DESCRIPTION
Fixes the reset routines after the player exits Seafoam Islands having only partially completed any of the floors' puzzles.