### PR TITLE
Seafoam Islands: Tweak Variant for Lite Version

### DIFF
--- a/scripts/route20.asm
+++ b/scripts/route20.asm
@@ -1,7 +1,11 @@
 
 Route20Script:
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; wispnote - These routines reset the boulders' positions if the a floor's puzzle
+; is not completely solved but were neglecting to reset the individual events; an oversight.
 	CheckAndResetEvent EVENT_IN_SEAFOAM_ISLANDS
 	call nz, Route20Script_50cc6
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 	call EnableAutoTextBoxDrawing
 	ld hl, Route20TrainerHeader0
 	ld de, Route20ScriptPointers
@@ -18,6 +22,8 @@ Route20Script_50cc6:
 	call Route20Script_50d0c
 	ld a, HS_SEAFOAM_ISLANDS_1_BOULDER_2
 	call Route20Script_50d0c
+	; wispnote - Also reset the individual events.
+	ResetEvents EVENT_SEAFOAM3_BOULDER1_DOWN_HOLE, EVENT_SEAFOAM3_BOULDER2_DOWN_HOLE
 	ld hl, .MissableObjectIDs
 .asm_50cdc
 	ld a, [hli]
@@ -48,6 +54,8 @@ Route20Script_50cc6:
 	call Route20Script_50d14
 	ld a, HS_SEAFOAM_ISLANDS_5_BOULDER_2
 	call Route20Script_50d14
+	; wispnote - Also reset the individual events.
+	ResetEvents EVENT_SEAFOAM4_BOULDER1_DOWN_HOLE, EVENT_SEAFOAM4_BOULDER2_DOWN_HOLE
 	ret
 
 Route20Script_50d0c:

--- a/scripts/route20.asm
+++ b/scripts/route20.asm
@@ -3,8 +3,9 @@ Route20Script:
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; wispnote - These routines reset the boulders' positions if the a floor's puzzle
 ; is not completely solved but were neglecting to reset the individual events; an oversight.
-	CheckAndResetEvent EVENT_IN_SEAFOAM_ISLANDS
-	call nz, Route20Script_50cc6
+; Removed the routines since there is no practical reason of resetting anything in this puzzles.
+	; CheckAndResetEvent EVENT_IN_SEAFOAM_ISLANDS
+	; call nz, Route20Script_50cc6
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 	call EnableAutoTextBoxDrawing
 	ld hl, Route20TrainerHeader0


### PR DESCRIPTION
I suggest completely remove the reset routines from the Seafoam Islands Puzzle.

It is really a matter of preference, but I find it weird to reset only if the floor's puzzle is incomplete. It makes more sense to either always reset after exiting in which case we don't need the individual checks or not resetting at all.

I propose the second option because the Cinnabar Island can also be accessed from Palette Town; hence the Seafoam Islands can be accessed from both sides without solving the puzzle. This means that BF4 puzzle is meaningful only if the puzzle does not reset after exiting. As for the BF5 puzzle, since both boulders can fall through without ever exiting BF4 resetting it if partially completed is not a difficulty factor like BF4's case.