### PR TITLE
Fixed Rival's Bubble Text on Route 22 (Lite Version)

### DIFF
--- a/scripts/oakslab.asm
+++ b/scripts/oakslab.asm
@@ -635,9 +635,12 @@ OaksLabScript17:
 	SetEvent EVENT_1ST_ROUTE22_RIVAL_BATTLE
 	ResetEventReuseHL EVENT_2ND_ROUTE22_RIVAL_BATTLE
 	SetEventReuseHL EVENT_ROUTE22_RIVAL_WANTS_BATTLE
-	ld a, HS_ROUTE_22_RIVAL_1
-	ld [wMissableObjectIndex], a
-	predef ShowObject
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; wispnote - Move this routine to be executed upon encounter.
+	; ld a, HS_ROUTE_22_RIVAL_1
+	; ld [wMissableObjectIndex], a
+	; predef ShowObject
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 	ld a, $5
 	ld [wPalletTownCurScript], a
 	xor a

--- a/scripts/pewtergym.asm
+++ b/scripts/pewtergym.asm
@@ -68,9 +68,13 @@ PewterGymScript_5c3df:
 	ld a, HS_GYM_GUY
 	ld [wMissableObjectIndex], a
 	predef HideObject
-	ld a, HS_ROUTE_22_RIVAL_1
-	ld [wMissableObjectIndex], a
-	predef HideObject
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; wispnote - Reseting the event instead of hiding the missable object is preferable in this case.
+	ResetEvents EVENT_1ST_ROUTE22_RIVAL_BATTLE, EVENT_ROUTE22_RIVAL_WANTS_BATTLE
+	; ld a, HS_ROUTE_22_RIVAL_1
+	; ld [wMissableObjectIndex], a
+	; predef HideObject
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 	ResetEvents EVENT_1ST_ROUTE22_RIVAL_BATTLE, EVENT_ROUTE22_RIVAL_WANTS_BATTLE
 

--- a/scripts/pewtergym.asm
+++ b/scripts/pewtergym.asm
@@ -69,8 +69,7 @@ PewterGymScript_5c3df:
 	ld [wMissableObjectIndex], a
 	predef HideObject
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; wispnote - Reseting the event instead of hiding the missable object is preferable in this case.
-	ResetEvents EVENT_1ST_ROUTE22_RIVAL_BATTLE, EVENT_ROUTE22_RIVAL_WANTS_BATTLE
+; wispnote - No longer necessary since the missable object is hidden until encounter.
 	; ld a, HS_ROUTE_22_RIVAL_1
 	; ld [wMissableObjectIndex], a
 	; predef HideObject

--- a/scripts/route22.asm
+++ b/scripts/route22.asm
@@ -36,6 +36,7 @@ Route22Script_50ed6:
 	ret
 
 Route22MoveRivalSprite:
+	call SetSpriteMovementBytesToFF
 	ld de, Route22RivalMovementData
 	ld a, [wcf0d]
 	cp $1
@@ -80,6 +81,12 @@ Route22Script0:
 	db $FF
 
 .firstRivalBattle
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Show rival's sprite before executing the event's routine.
+	ld a, HS_ROUTE_22_RIVAL_1
+	ld [wMissableObjectIndex], a
+	predef ShowObject
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 	ld a, $1
 	ld [wEmotionBubbleSpriteIndex], a
 	xor a ; EXCLAMATION_BUBBLE
@@ -233,6 +240,12 @@ Route22Script3:
 	ret
 
 Route22Script_5104e:
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Show rival's sprite before executing the event's routine.
+	ld a, HS_ROUTE_22_RIVAL_2
+	ld [wMissableObjectIndex], a
+	predef ShowObject
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 	ld a, $2
 	ld [wEmotionBubbleSpriteIndex], a
 	xor a ; EXCLAMATION_BUBBLE

--- a/scripts/route22.asm
+++ b/scripts/route22.asm
@@ -36,7 +36,6 @@ Route22Script_50ed6:
 	ret
 
 Route22MoveRivalSprite:
-	call SetSpriteMovementBytesToFF
 	ld de, Route22RivalMovementData
 	ld a, [wcf0d]
 	cp $1

--- a/scripts/viridiangym.asm
+++ b/scripts/viridiangym.asm
@@ -162,9 +162,12 @@ ViridianGymScript3_74995:
 	; deactivate gym trainers
 	SetEventRange EVENT_BEAT_VIRIDIAN_GYM_TRAINER_0, EVENT_BEAT_VIRIDIAN_GYM_TRAINER_7
 
-	ld a, HS_ROUTE_22_RIVAL_2
-	ld [wMissableObjectIndex], a
-	predef ShowObject
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; wispnote - Move this routine to be executed upon encounter.
+	; ld a, HS_ROUTE_22_RIVAL_2
+	; ld [wMissableObjectIndex], a
+	; predef ShowObject
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 	SetEvents EVENT_2ND_ROUTE22_RIVAL_BATTLE, EVENT_ROUTE22_RIVAL_WANTS_BATTLE
 	jp ViridianGymScript_748d6
 


### PR DESCRIPTION
The rival's bubble text appeared out of place since it was shown before the referenced sprite was moved inside the screen's region. I modified the related routines in order for the missable object (the rival's sprite) to be shown at the time of the encounter. This fixed the issue.