### PR TITLE
Corrected the BugFix regarding skipped moves after PKMN evolution

### DIFF
--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -223,34 +223,7 @@ SetScrollXForSlidingPlayerBodyLeft:
 StartBattle:	;joedebug - start of the battle
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; wispnote - Store PKMN Levels at the Beggining of the Battle.
-	xor a
-	ld [wMonDataLocation], a
-	ld [wWhichPokemon], a
-	ld hl, wPartyCount
-	ld de, wStartBattleLevels
-	push de
-	push hl
-.loopStorePKMNLevels
-	pop hl
-	inc hl
-	ld a, [hl]
-	cp $ff
-	jp z, .doneStorePKMNLevels
-	push hl
-	call LoadMonData
-	pop hl
-	pop de
-	ld a, [wWhichPokemon]
-	inc a
-	ld [wWhichPokemon], a
-	ld a, [wLoadedMonLevel]
-	ld [de], a
-	inc de
-	push de
-	push hl
-	jp .loopStorePKMNLevels
-.doneStorePKMNLevels
-	pop de	
+	callba StorePKMNLevels
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 	xor a
 	ld [wPartyGainExpFlags], a

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -221,6 +221,37 @@ SetScrollXForSlidingPlayerBodyLeft:
 	ret
 
 StartBattle:	;joedebug - start of the battle
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; wispnote - Store PKMN Levels at the Beggining of the Battle.
+	xor a
+	ld [wMonDataLocation], a
+	ld [wWhichPokemon], a
+	ld hl, wPartyCount
+	ld de, wStartBattleLevels
+	push de
+	push hl
+.loopStorePKMNLevels
+	pop hl
+	inc hl
+	ld a, [hl]
+	cp $ff
+	jp z, .doneStorePKMNLevels
+	push hl
+	call LoadMonData
+	pop hl
+	pop de
+	ld a, [wWhichPokemon]
+	inc a
+	ld [wWhichPokemon], a
+	ld a, [wLoadedMonLevel]
+	ld [de], a
+	inc de
+	push de
+	push hl
+	jp .loopStorePKMNLevels
+.doneStorePKMNLevels
+	pop de	
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 	xor a
 	ld [wPartyGainExpFlags], a
 	ld [wPartyFoughtCurrentEnemyFlags], a

--- a/engine/battle/stats_functions.asm
+++ b/engine/battle/stats_functions.asm
@@ -546,7 +546,39 @@ IsRunning:
 	ret
 	
 
-	
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; wispnote - This function called to store PKMN Levels at the Beggining of the Battle.
+; Used letter for correctly perform the evolution routine.
+StorePKMNLevels:
+	xor a
+	ld [wMonDataLocation], a
+	ld [wWhichPokemon], a
+	ld hl, wPartyCount
+	ld de, wStartBattleLevels
+	push de
+	push hl
+.loopStorePKMNLevels
+	pop hl
+	inc hl
+	ld a, [hl]
+	cp $ff
+	jp z, .doneStorePKMNLevels
+	push hl
+	call LoadMonData
+	pop hl
+	pop de
+	ld a, [wWhichPokemon]
+	inc a
+	ld [wWhichPokemon], a
+	ld a, [wLoadedMonLevel]
+	ld [de], a
+	inc de
+	push de
+	push hl
+	jp .loopStorePKMNLevels
+.doneStorePKMNLevels
+	pop de	
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
 

--- a/engine/battle/stats_functions.asm
+++ b/engine/battle/stats_functions.asm
@@ -577,7 +577,8 @@ StorePKMNLevels:
 	push hl
 	jp .loopStorePKMNLevels
 .doneStorePKMNLevels
-	pop de	
+	pop de
+	ret
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 

--- a/engine/evos_moves.asm
+++ b/engine/evos_moves.asm
@@ -22,6 +22,11 @@ EvolutionAfterBattle:
 	push hl
 	push bc
 	push de
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; wispnote - We keep a pointer to the current PKMN's Level at the Beginning of the Battle.
+	ld hl, wStartBattleLevels
+	push hl
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 	ld hl, wPartyCount
 	push hl
 
@@ -29,11 +34,20 @@ Evolution_PartyMonLoop: ; loop over party mons
 	ld hl, wWhichPokemon
 	inc [hl]
 	pop hl
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; wispnote - We store current PKMN' Level at the Beginning of the Battle
+; to a chosen memory address in order to be compaired later with the evolution requirements.
+	pop de
+	ld a, [de]
+	ld [wTempCoins1], a
+	inc de
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 	inc hl
 	ld a, [hl]
 	cp $ff ; have we reached the end of the party?
 	jp z, .done
 	ld [wEvoOldSpecies], a
+	push de; wispnote - If we are not done we need to push the pointer for the next iteration.
 	push hl
 	ld a, [wWhichPokemon]
 	ld c, a
@@ -119,8 +133,13 @@ Evolution_PartyMonLoop: ; loop over party mons
 ;			learning moves of the new evolution to be skipped.
 			;need to store the evo level requirement somewhere.
 	;wTempCoins1 was chosen because it's used only for slot machine and gets defaulted to 1 during the mini-game
+; wispnote - We compare with PKMN's level at the Beginning of the Battle and keep the highest value.
+	ld a, [wTempCoins1]
+	cp b
+	jp nc, .evoLevelRequirementSatisfied
 	ld a, b
-	ld [wTempCoins1], a	
+	ld [wTempCoins1], a
+.evoLevelRequirementSatisfied
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 	push hl

--- a/wram.asm
+++ b/wram.asm
@@ -3278,7 +3278,13 @@ wBoxMonNicksEnd::
 
 wBoxDataEnd::
 
-; dee2
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; wispnote - PKMN Levels at the Begining of a Battle.
+; Required to correctly execute the level-up procedure.
+wStartBattleLevels:: ds PARTY_LENGTH; dee2
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; dee8; wispnote - Updated to account for the new variables.
 
 SECTION "Stack", WRAM0[$df00]
 	ds $ff


### PR DESCRIPTION
We needed to account for the PKMN level at the beginning of the battle. I had to declare some pointers in WRAM to keep track of that but if you believe we can reuse some space I can change it.

EDIT: Maybe the free space after wFlags_0xcd60. It doesn't seem to be used during a battle.