### PR TITLE
Build fix for shinpokered in latest RGBDS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,31 +68,31 @@ endif
 
 %_red.o: dep = $(shell tools/scan_includes $(@D)/$*.asm)
 $(pokered_obj): %_red.o: %.asm $$(dep)
-	rgbasm -D _RED -D _SWBACKS -D _FPLAYER -D _MOVENPCS -D _RUNSHOES -D _EXPBAR -h -o $@ $*.asm
+	rgbasm -D _RED -D _SWBACKS -D _FPLAYER -D _MOVENPCS -D _RUNSHOES -D _EXPBAR -l -h -o $@ $*.asm
 
 %_blue.o: dep = $(shell tools/scan_includes $(@D)/$*.asm)
 $(pokeblue_obj): %_blue.o: %.asm $$(dep)
-	rgbasm -D _BLUE -D _SWBACKS -D _FPLAYER -D _MOVENPCS -D _RUNSHOES -D _EXPBAR -h -o $@ $*.asm
+	rgbasm -D _BLUE -D _SWBACKS -D _FPLAYER -D _MOVENPCS -D _RUNSHOES -D _EXPBAR -l -h -o $@ $*.asm
 
 %_green.o: dep = $(shell tools/scan_includes $(@D)/$*.asm)
 $(pokegreen_obj): %_green.o: %.asm $$(dep)
-	rgbasm -D _GREEN -D _RGSPRITES -D _REDGREENJP -D _JPTXT -D _METRIC -D _FPLAYER -D _MOVENPCS -D _RUNSHOES -D _EXPBAR -h -o $@ $*.asm
+	rgbasm -D _GREEN -D _RGSPRITES -D _REDGREENJP -D _JPTXT -D _METRIC -D _FPLAYER -D _MOVENPCS -D _RUNSHOES -D _EXPBAR -l -h -o $@ $*.asm
 	
 %_red_origback.o: dep = $(shell tools/scan_includes $(@D)/$*.asm)
 $(pokered_origback_obj): %_red_origback.o: %.asm $$(dep)
-	rgbasm -D _RED -D _FPLAYER -D _MOVENPCS -D _RUNSHOES -D _EXPBAR -h -o $@ $*.asm
+	rgbasm -D _RED -D _FPLAYER -D _MOVENPCS -D _RUNSHOES -D _EXPBAR -l -h -o $@ $*.asm
 
 %_blue_origback.o: dep = $(shell tools/scan_includes $(@D)/$*.asm)
 $(pokeblue_origback_obj): %_blue_origback.o: %.asm $$(dep)
-	rgbasm -D _BLUE -D _FPLAYER -D _MOVENPCS -D _RUNSHOES -D _EXPBAR -h -o $@ $*.asm
+	rgbasm -D _BLUE -D _FPLAYER -D _MOVENPCS -D _RUNSHOES -D _EXPBAR -l -h -o $@ $*.asm
 
 %_bluejp.o: dep = $(shell tools/scan_includes $(@D)/$*.asm)
 $(pokebluejp_obj): %_bluejp.o: %.asm $$(dep)
-	rgbasm -D _BLUE -D _BLUEJP -D _JPTXT -D _METRIC -D _FPLAYER -D _MOVENPCS -D _RUNSHOES -D _EXPBAR -h -o $@ $*.asm
+	rgbasm -D _BLUE -D _BLUEJP -D _JPTXT -D _METRIC -D _FPLAYER -D _MOVENPCS -D _RUNSHOES -D _EXPBAR -l -h -o $@ $*.asm
 
 %_redjp.o: dep = $(shell tools/scan_includes $(@D)/$*.asm)
 $(pokeredjp_obj): %_redjp.o: %.asm $$(dep)
-	rgbasm -D _RED -D _RGSPRITES -D _REDGREENJP -D _REDJP -D _JPTXT -D _METRIC -D _FPLAYER -D _MOVENPCS -D _RUNSHOES -D _EXPBAR -h -o $@ $*.asm
+	rgbasm -D _RED -D _RGSPRITES -D _REDGREENJP -D _REDJP -D _JPTXT -D _METRIC -D _FPLAYER -D _MOVENPCS -D _RUNSHOES -D _EXPBAR -l -h -o $@ $*.asm
 
 #gbcnote - use cjsv to compile as GBC+DMG rom
 pokered_opt  = -cjsv -k 01 -l 0x33 -m 0x13 -p 0 -r 03 -t "POKEMON RED"

--- a/constants/misc_constants.asm
+++ b/constants/misc_constants.asm
@@ -40,7 +40,7 @@ D_LEFT   EQU %00100000
 D_UP     EQU %01000000
 D_DOWN   EQU %10000000
 
-const_value set 0
+	const_def
 	const BIT_A_BUTTON
 	const BIT_B_BUTTON
 	const BIT_SELECT


### PR DESCRIPTION
An unupdated `const_def` breaks the build in at least RGBDS 0.5.2+
ld optimization warnings also appear when building unless given the -l option.
Both are fixed in this PR.