### PR TITLE
Link upstream tree at time of fork in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1356,4 +1356,4 @@ The following folks for their help in pointing out and diagnosing bugs
 - Chirutalis 
 
   
-The shinpokered repository was branched from pret/pokered at merge pull request #185 committed on Jul 2, 2018
+The shinpokered repository was branched from pret/pokered at [merge pull request #185 committed on Jul 2, 2018](https://github.com/pret/pokered/tree/c8599831992c91e521cf1d467ccae3d9498e42ef)


### PR DESCRIPTION
Adds a link to the tree of the exact commit this was forked from in the readme if you want to peer into shinpokered's past.